### PR TITLE
Admin layout

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -9,7 +9,7 @@ class ItemView(ModelView):
 
 class InvoiceView(ModelView):
     # column_hide_backrefs = False # Discord antwort
-    # form_columns = ["kunde", "datum", "betrag", "beglichen", "items"] # Discord antwort
+    # form_columns = ["kunde", "datum", "betrag", "beglichen", "items"] # Discord antwort  # noqa: E501
     #! Discort Lines führen zu Fehler bei admin/invoicemodel 
     #! TypeError: __str__ returned non-string (type int)
     form_excluded_columns = ['items']

--- a/admin.py
+++ b/admin.py
@@ -2,10 +2,14 @@ from flask_admin.contrib.sqla import ModelView
 
 class ClientView(ModelView):
     form_excluded_columns = ['invoices']
-
+    
 class ItemView(ModelView):
     form_excluded_columns = ['invoice']
     column_exclude_list = ['anzahl']
 
 class InvoiceView(ModelView):
+    # column_hide_backrefs = False # Discord antwort
+    # form_columns = ["kunde", "datum", "betrag", "beglichen", "items"] # Discord antwort
+    #! Discort Lines führen zu Fehler bei admin/invoicemodel 
+    #! TypeError: __str__ returned non-string (type int)
     form_excluded_columns = ['items']

--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ def create_app():
     app.config['DEBUG'] = True
 
     admin = Admin(app, template_mode='bootstrap3')
+    # admin = Admin(app, base_template='/templates/admin/master.html')
     admin.add_view(ClientView(ClientModel, db.session))
     admin.add_view(ItemView(ItemModel, db.session))
     admin.add_view(InvoiceView(InvoiceModel, db.session))

--- a/models.py
+++ b/models.py
@@ -22,7 +22,7 @@ class InvoiceModel(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     datum = db.Column(db.Date)
-    betrag = db.Column(db.Numeric)    
+    betrag = db.Column(db.Numeric(7,2))    
     beglichen = db.Column(db.Boolean)
 
     kunde = db.Column(db.Integer, db.ForeignKey('client.id'))

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 *,
 *::after,
 *::before {
@@ -137,12 +138,19 @@ body {
   width: 10rem; }
   .table__stueckpreis input {
     text-align: right; }
-  .table__stueckpreis input::-webkit-outer-spin-button,
-  .table__stueckpreis input::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0; }
+    .table__stueckpreis input::-webkit-outer-spin-button, .table__stueckpreis input::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0; }
 
 .table__anzahl {
   width: 5rem; }
   .table__anzahl input {
     text-align: right; }
+    .table__anzahl input[type=number]::-webkit-inner-spin-button, .table__anzahl input[type=number]::-webkit-outer-spin-button {
+      opacity: 1; }
+
+tbody .col-betrag, tbody .col-stueckpreis {
+  color: green;
+  text-align: right; }
+  tbody .col-betrag::after, tbody .col-stueckpreis::after {
+    content: '€'; }

--- a/static/sass/_admin.scss
+++ b/static/sass/_admin.scss
@@ -1,6 +1,9 @@
-.col-betrag {
-    color: green;
-    &::after {
-        content: '€';
+tbody{
+    .col-betrag, .col-stueckpreis {
+        color: green;
+        text-align: right;
+        &::after {
+            content: '€';
+        }
     }
 }

--- a/static/sass/_new-invoice.scss
+++ b/static/sass/_new-invoice.scss
@@ -27,13 +27,13 @@
 
         input {
             text-align: right;
-        }
 
-        input::-webkit-outer-spin-button,
-        input::-webkit-inner-spin-button {
-            -webkit-appearance: none;
-            margin: 0;
-        }
+            &::-webkit-outer-spin-button,
+            &::-webkit-inner-spin-button {
+                -webkit-appearance: none;
+                margin: 0;
+            }
+        }        
     }
 
     &__anzahl {
@@ -41,7 +41,12 @@
 
         input {
             text-align: right;
-        }
+
+            &[type=number]::-webkit-inner-spin-button, 
+            &[type=number]::-webkit-outer-spin-button {
+                opacity: 1;
+            }
+        }        
     }
 
 }

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -2,3 +2,4 @@
 @import "base";
 @import "invoice-float";
 @import "new-invoice";
+@import "admin";

--- a/templates/admin/master.html
+++ b/templates/admin/master.html
@@ -1,0 +1,8 @@
+{% extends admin_base_template %}
+  
+
+{% block head_css %}
+  {{ super() }}
+  <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet" >
+{% endblock %}
+


### PR DESCRIPTION
Preise mithilfe von format{} an Währungsformat angeglichen. Beschränkung auf 2 Nachkommastellen. "€"-Symbol hinzugefügt. Tausenderpunkt wird aber nicht angezeigt und Nachkommastellen werden mit "." statt mit "," separiert. 
Dazu musste der admin master überschrieben werden. D.h. Anlage eines eigenen master.html damit dort die eigene CSS eingebunden werden konnte (zum Hinzufügen des €-Zeichens per ::after) Vgl. _admin.scss
Leider sind jetzt die Increment Arrows im Feld 'Anzahl' (neue Rechnung) weg. 